### PR TITLE
fix: implement proper deep linking using Telegram start_param

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Telegram Bot Token (use different bot token for each environment)
 TELEGRAM_BOT_TOKEN=123456789:your_bot_token_here
 
+# Bot username (without @)
+BOT_USERNAME=fleamarketx_bot
+
 # Telegram ID of your account
 TELEGRAM_ADMIN_ID=987654321
 

--- a/backend/src/webhook.ts
+++ b/backend/src/webhook.ts
@@ -21,7 +21,28 @@ export async function handleWebhook(c: Context) {
 
   bot.command("start", async (ctx: GrammyContext) => {
     const firstName = ctx.from?.first_name || "User";
+    const startParam = ctx.match; // Gets the parameter after /start
 
+    // If start parameter is provided (e.g., /start listing_123)
+    if (startParam && startParam.toString().startsWith("listing_")) {
+      const listingId = startParam.toString().replace("listing_", "");
+      const webappUrl = c.env.WEBAPP_URL || c.env.PAGES_URL || "https://fleamarket-twa.pages.dev";
+
+      await ctx.reply(
+        `🛍️ Check out this listing!`,
+        {
+          reply_markup: {
+            inline_keyboard: [[{
+              text: "View Listing",
+              web_app: { url: `${webappUrl}?startParam=listing_${listingId}` }
+            }]]
+          }
+        }
+      );
+      return;
+    }
+
+    // Default welcome message
     await ctx.reply(
       `👋 Hello ${firstName}!\n\nWelcome to the Telegram Web App Template!\n\nhttps://github.com/thesameorg/telegram-webapp-cloudflare-template/`,
     );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,14 @@ function App() {
       } else {
         document.documentElement.classList.remove("dark");
       }
+
+      // Handle deep link via start_param
+      const startParam = webApp.initDataUnsafe?.start_param;
+      if (startParam && startParam.startsWith("listing_")) {
+        const listingId = startParam.replace("listing_", "");
+        // Store the redirect path in sessionStorage for the router to pick up
+        sessionStorage.setItem("deepLinkRedirect", `/listings/${listingId}`);
+      }
     }
   }, [webApp, isWebAppReady]);
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,5 @@
-import { Outlet } from "react-router-dom";
+import { useEffect } from "react";
+import { Outlet, useNavigate } from "react-router-dom";
 import BottomNavigation from "./BottomNavigation";
 import AuthRequired from "./AuthRequired";
 import LoadingSpinner from "./LoadingSpinner";
@@ -6,6 +7,18 @@ import { useAuth } from "../contexts/AuthContext";
 
 export default function Layout() {
   const { isAuthenticated, isLoading } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // Check for deep link redirect after authentication
+    if (isAuthenticated) {
+      const redirectPath = sessionStorage.getItem("deepLinkRedirect");
+      if (redirectPath) {
+        sessionStorage.removeItem("deepLinkRedirect");
+        navigate(redirectPath);
+      }
+    }
+  }, [isAuthenticated, navigate]);
 
   if (isLoading) {
     return <LoadingSpinner />;

--- a/frontend/src/components/ShareButton.tsx
+++ b/frontend/src/components/ShareButton.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+
+interface ShareButtonProps {
+  listingId: number;
+  title: string;
+}
+
+export function ShareButton({ listingId, title }: ShareButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = async () => {
+    const botUsername = import.meta.env.VITE_BOT_USERNAME || "fleamarketx_bot";
+    const shareUrl = `https://t.me/${botUsername}?start=listing_${listingId}`;
+    const shareText = `Check out this cool item I found: ${title}\n${shareUrl}`;
+
+    // Try Web Share API first (works on mobile)
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: `Check out: ${title}`,
+          text: shareText,
+        });
+        return;
+      } catch (err) {
+        // User cancelled or share failed, fall back to clipboard
+        if ((err as Error).name !== "AbortError") {
+          console.error("Share failed:", err);
+        }
+      }
+    }
+
+    // Fallback: copy to clipboard
+    try {
+      await navigator.clipboard.writeText(shareText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+      alert("Failed to share. Please try again.");
+    }
+  };
+
+  return (
+    <button
+      onClick={handleShare}
+      className="w-full bg-blue-500 text-white py-3 rounded-lg font-medium hover:bg-blue-600 transition-colors"
+    >
+      {copied ? "✓ Copied!" : "📤 Share"}
+    </button>
+  );
+}

--- a/frontend/src/pages/ListingDetail.tsx
+++ b/frontend/src/pages/ListingDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { listingsApi, type Listing } from "../services/listingsApi";
 import { useAuth } from "../contexts/AuthContext";
 import { ListingTimer } from "../components/ListingTimer";
+import { ShareButton } from "../components/ShareButton";
 import {
   formatPrice,
   getCategoryById,
@@ -249,16 +250,26 @@ export default function ListingDetail() {
 
         {/* Actions */}
         <div className="space-y-2">
-          {/* Contact Button */}
-          {listing.profile?.username && !isOwner && (
-            <a
-              href={`https://t.me/${listing.profile.username}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block w-full bg-blue-500 text-white text-center py-3 rounded-lg font-medium hover:bg-blue-600"
-            >
-              💬 Contact Seller
-            </a>
+          {/* Contact & Share Buttons for non-owners */}
+          {!isOwner && (
+            <div className="grid grid-cols-2 gap-2">
+              {listing.profile?.username && (
+                <a
+                  href={`https://t.me/${listing.profile.username}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="bg-blue-500 text-white text-center py-3 rounded-lg font-medium hover:bg-blue-600"
+                >
+                  💬 Contact
+                </a>
+              )}
+              <ShareButton listingId={listing.id} title={listing.title} />
+            </div>
+          )}
+
+          {/* Share Button for owners */}
+          {isOwner && (
+            <ShareButton listingId={listing.id} title={listing.title} />
           )}
 
           {/* Owner Actions */}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -33,6 +33,7 @@ bucket_name = "fleamarket-r2"
 [vars]
 ENVIRONMENT = "production"
 PAGES_URL = "https://fleamarket-twa.pages.dev"
+BOT_USERNAME = "fleamarketx_bot"
 
 # Pages configuration
 pages_build_output_dir = "frontend/dist"


### PR DESCRIPTION
## Summary

Fixed deep linking to properly use Telegram's `start_param` API as documented in Telegram Mini Apps documentation.

## Changes

- Update `/start` command in webhook to parse deep link parameters
- Add WebApp button with startParam in URL for deep links
- Read `start_param` from `initDataUnsafe` in App.tsx
- Implement redirect logic in Layout.tsx after authentication
- Create ShareButton component with Web Share API fallback
- Add share button to ListingDetail page next to Contact button
- Add BOT_USERNAME environment variable configuration

## How It Works

1. User shares listing → generates `https://t.me/fleamarketx_bot?start=listing_123`
2. Recipient clicks link → bot sends WebApp button
3. WebApp reads `start_param` from `initDataUnsafe`
4. After auth, user auto-redirected to `/listings/123`

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)